### PR TITLE
#38 Adds support for filtering products by category title or id

### DIFF
--- a/src/GraphQL/Builders/ProductsBuilder.php
+++ b/src/GraphQL/Builders/ProductsBuilder.php
@@ -19,4 +19,19 @@ class ProductsBuilder
 
         return $query;
     }
+
+    public function byCategory($root, array $args, $context, ResolveInfo $resolveInfo)
+    {
+        if(isset($args['input'])){
+            if( isset($args['input']['ids'])){
+                $query = Product::byCategoryIds($args['input']['ids']);
+            } else if(isset($args['input']['titles'])) {
+                $query = Product::byCategoryTitles($args['input']['titles']);
+            }
+        } else {
+            $query = Product::query();
+        }
+
+        return $query;
+    }
 }

--- a/src/GraphQL/schema/products.graphql
+++ b/src/GraphQL/schema/products.graphql
@@ -6,11 +6,25 @@ extend type Query {
             scopes: ["published", "inStock"],
             builder: "Lab19\\Cart\\GraphQL\\Builders\\ProductsBuilder@search"
         )
+
     product(id: ID @eq): Product @find(model: "Lab19\\Cart\\Models\\Product")
+
+    productsByCategories(input:ProductsCategoriesInput): [Product!]!
+        @paginate(
+            type: "paginator",
+            model: "Lab19\\Cart\\Models\\Product",
+            scopes: ["published", "inStock"],
+            builder: "Lab19\\Cart\\GraphQL\\Builders\\ProductsBuilder@byCategory"
+        )
 }
 
 input ProductsQueryInput {
     keyword: String
+}
+
+input ProductsCategoriesInput {
+    ids: [Int!],
+    titles: [String!]
 }
 
 type Product {

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -7,6 +7,7 @@
     use Illuminate\Database\Eloquent\Relations\HasMany;
     use Illuminate\Database\Eloquent\Relations\HasManyThrough;
     use Illuminate\Database\Eloquent\Relations\MorphToMany;
+    use Illuminate\Database\Eloquent\Builder;
 
     use Lab19\Cart\Models\Category;
 
@@ -199,6 +200,31 @@
          */
         public function scopeSearchByKeyword( $query, String $keyword ){
             return $query->where('title', 'like', '%' . $keyword . '%' );
+        }
+
+        /**
+         * Scope by category(s) ids
+         *
+         * @var $query
+         */
+        public function scopeByCategoryIds( $query, Array $ids ){
+            $result = $query->whereHas('categories', function (Builder $q) use ($ids){
+                $q->whereIn('category_id', $ids);
+            });
+            return $result;
+        }
+
+        /**
+         * Scope by category(s) titles
+         *
+         * @var $query
+         */
+        public function scopeByCategoryTitles( $query, Array $titles ){
+            return $query->whereHas('categories', function (Builder $q) use ($titles){
+                foreach( $titles as $title ){
+                    $q->orWhere('title', 'LIKE', '%' . strtolower($title) . '%');
+                }
+            });
         }
 
         /**

--- a/src/tests/Unit/viewCategorisedProductsTest.php
+++ b/src/tests/Unit/viewCategorisedProductsTest.php
@@ -1,0 +1,98 @@
+<?php
+    use Lab19\Cart\Testing\TestCase;
+    use Lab19\Cart\Models\Product;
+    use Lab19\Cart\Models\Category;
+
+    /**
+     * @group ProductCategories
+     */
+    class TestViewCategorisedProducts extends TestCase
+    {
+
+        public function setUp(): void
+        {
+            parent::setUp();
+            $this->availableCount = 11;
+            $cat1 = new Category([ 'title' => 'Coffee' ]);
+            $cat2 = new Category([ 'title' => 'Kitchen' ]);
+            $cat1->save();
+            $cat2->save();
+            $this->cat1 = $cat1;
+            $this->cat2 = $cat2;
+
+            factory(Product::class, $this->availableCount)->create()->each( function( $product ) use( $cat1, $cat2 ) {
+                $product->status = 'IN_STOCK';
+                $product->title = 'Coffee pod';
+                $product->published = 1;
+                $product->categories()->attach($cat1);
+                $product->categories()->attach($cat2);
+                $product->save();
+            });
+        }
+
+        public function testGuestUserCanQueryProductsByCategoryTitles(): void
+        {
+            $response = $this->graphQL('
+                query {
+                    productsByCategories(count: 11, input: {titles: ["kitchen"] }) {
+                        data {
+                            id
+                            categories {
+                                id
+                                title
+                            }
+                        }
+                    }
+                }
+            ');
+
+            $response->assertDontSee('errors');
+
+            $result = $response->decodeResponseJson();
+
+            $this->assertCount($this->availableCount, $result['data']['productsByCategories']['data'] );
+
+            $response->assertJsonStructure([
+                'data' => [
+                    'productsByCategories' => [
+                        'data' => [
+                            ['id', 'categories' => [['id', 'title']] ],
+                        ]
+                    ]
+                ]
+            ]);
+        }
+
+        public function testGuestUserCanQueryProductsByCategoryIds(): void
+        {
+            $response = $this->graphQL('
+                query {
+                    productsByCategories(count: 11, input: {ids: [' . $this->cat1->id . ', ' . $this->cat2->id . '] }) {
+                        data {
+                            id
+                            categories {
+                                id
+                                title
+                            }
+                        }
+                    }
+                }
+            ');
+
+            $response->assertDontSee('errors');
+
+            $result = $response->decodeResponseJson();
+
+            $this->assertCount($this->availableCount, $result['data']['productsByCategories']['data'] );
+
+            $response->assertJsonStructure([
+                'data' => [
+                    'productsByCategories' => [
+                        'data' => [
+                            ['id', 'categories' => [['id', 'title']] ],
+                        ]
+                    ]
+                ]
+            ]);
+        }
+    }


### PR DESCRIPTION
Can now query products by category title or id using the following graphql endpoints.

```
query {
 productsByCategories(count: 11, input: {titles: ["kitchen"]}){
   data { ... }
 }
}

query {
 productsByCategories(count: 11, input: {ids: [2, 3]}){
   data { ... }
 }
}
```