### PR TITLE
#34 Ability to enable featured image on product through attribute

### DIFF
--- a/src/Actions/Helpers/Attributes.php
+++ b/src/Actions/Helpers/Attributes.php
@@ -2,6 +2,7 @@
 namespace Lab19\Cart\Actions\Helpers;
 
 use Lab19\Cart\Models\Product;
+use Lab19\Cart\Models\Image;
 use Lab19\Cart\Models\ProductAttribute;
 
 class Attributes
@@ -103,6 +104,21 @@ class Attributes
                 'value' => $id
             ];
         }
+        return $this;
+    }
+
+    public function featuredImage( $image ): Attributes
+    {
+        if( $this->product && $image instanceof Image ){
+            $this->product->productFeaturedImage()->delete();
+        }
+
+        $this->attributes[] = [
+            'group' => 'featured_image',
+            'key' => 'featured_image',
+            'value' => $image->id
+        ];
+
         return $this;
     }
 

--- a/src/Actions/ProductSetFeaturedImage.php
+++ b/src/Actions/ProductSetFeaturedImage.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Lab19\Cart\Actions;
+
+use Lab19\Cart\Models\Product;
+use Lab19\Cart\Models\Image;
+use Lab19\Cart\Actions\Helpers\Attributes;
+
+class ProductSetFeaturedImage
+{
+    public static function handle( Int $productId, Int $imageId ): Product
+    {
+        $product = Product::findOrFail($productId);
+        $image = Image::findOrFail( $imageId );
+        $attributes = new Attributes($product);
+        $attributes->featuredImage($image);
+        $product->attributes()->createMany(
+            $attributes->toArray()
+        );
+        return $product;
+    }
+
+}

--- a/src/GraphQL/Mutations/Product.php
+++ b/src/GraphQL/Mutations/Product.php
@@ -10,6 +10,7 @@ use Lab19\Cart\Actions\CreateProductVariant;
 use Lab19\Cart\Actions\UpdateProduct;
 use Lab19\Cart\Actions\DeleteProduct;
 use Lab19\Cart\Actions\ProductAttachImages;
+use Lab19\Cart\Actions\ProductSetFeaturedImage;
 use Lab19\Cart\Services\SessionService;
 use \App;
 
@@ -57,6 +58,15 @@ class Product
     {
         $attachImage = App::make(ProductAttachImages::class);
         $result = $attachImage->handle( $args['product_id'], $args['images'] );
+        return [
+            'product' => $result
+        ];
+    }
+
+    public function setFeaturedImage($rootValue, array $args, GraphQLContext $context, ResolveInfo $resolveInfo)
+    {
+        $setFeaturedImage = App::make(ProductSetFeaturedImage::class);
+        $result = $setFeaturedImage->handle( $args['product_id'], $args['image_id'] );
         return [
             'product' => $result
         ];

--- a/src/GraphQL/schema/products.graphql
+++ b/src/GraphQL/schema/products.graphql
@@ -47,6 +47,7 @@ type Product {
     dimensions: ProductDimensions
     weight: ProductWeight
     images: [Image!]
+    featured_image: Image
 }
 
 type ProductDimensions {
@@ -193,6 +194,13 @@ extend type Mutation {
             model: "Lab19\\Cart\\Models\\Product",
             policy: "Lab19\\Cart\\Policies\\ProductPolicy"
         )
+    setProductFeaturedImage(product_id: ID!, image_id: ID!): SetProductFeaturedImagePayload!
+        @field(resolver: "Lab19\\Cart\\GraphQL\\Mutations\\Product@setFeaturedImage")
+        @can(
+            ability: "create",
+            model: "Lab19\\Cart\\Models\\Product",
+            policy: "Lab19\\Cart\\Policies\\ProductPolicy"
+        )
 }
 
 input AddProductImage {
@@ -210,4 +218,8 @@ type Image {
 type AddProductImagesPayload {
     product: Product!
     images: [Image!]
+}
+
+type SetProductFeaturedImagePayload {
+    product: Product!
 }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -10,6 +10,7 @@
     use Illuminate\Database\Eloquent\Builder;
 
     use Lab19\Cart\Models\Category;
+    use Lab19\Cart\Models\Image;
 
     class Product extends Model {
 
@@ -128,6 +129,15 @@
          */
         public function productImages(){
             return $this->hasMany(ProductAttribute::class)->images();
+        }
+
+        /**
+         * Featured image relation
+         *
+         * @var $query
+         */
+        public function productFeaturedImage(){
+            return $this->hasMany(ProductAttribute::class)->featuredImage();
         }
 
         /**
@@ -253,6 +263,19 @@
                 $data[ $each->key ] = $each->value;
             }
             return $data;
+        }
+
+        /**
+         * FeaturedImage attribute
+         *
+         * @var Array $data
+         */
+        public function getFeaturedImageAttribute(){
+            $attributeArray = $this->getAttribute('productFeaturedImage');
+            foreach( $attributeArray as $each ){
+                $image = Image::find($each->value);
+                return $image;
+            }
         }
 
         /**

--- a/src/Models/ProductAttribute.php
+++ b/src/Models/ProductAttribute.php
@@ -53,6 +53,15 @@
         }
 
         /**
+         * Featured image relation
+         *
+         * @var $query
+         */
+        public function scopeFeaturedImage( $query ){
+            return $query->where('group', 'featured_image');
+        }
+
+        /**
          * Custom product meta scope
          * $product->meta()
          */


### PR DESCRIPTION
Users can interact with this on graphql api using the following method (the image must be created first). 

```
mutation {
    setProductFeaturedImage(product_id: 1, image_id: 1){
        product {
            id
            featured_image {
                id
                url
            }
        }
    }
}   
```